### PR TITLE
add otf functionality to archive_eigsys

### DIFF
--- a/archive_eigsys.py
+++ b/archive_eigsys.py
@@ -4,7 +4,6 @@
 import argument_parsing as ap
 import conf_utils
 import sys, os, tarfile, re, subprocess
-from subprocess import PIPE
 
 def calc_arcsize(t, l, nev, nconf=None):
     evecs_ts = nev*l**3*3*2*8
@@ -19,7 +18,7 @@ def cmp_sizes(arcpath,size,push,pop):
     sync = None
     if os.path.getsize(arcpath) >= size:
         print("\nSuccessfully packed %s" %arcpath)
-        # make shure to only append filename
+        # make sure to only append filename
         push.append(arcpath.split('/')[-1])
     else:
         print("\nEigensystem archive %s has wrong size:" %arcpath)

--- a/argument_parsing.py
+++ b/argument_parsing.py
@@ -51,6 +51,10 @@ def arg_parser():
                             default="")
 
     if progname == "archive_eigsys.py" or progname == "check_eigsys_v2.py":
+        parser.add_argument("--otf", help="Perform transfer 'on the fly', piping the output of the tar command directly to ssh.",
+                            dest="otf", 
+                            action="store_true",
+                            default=False)
         parser.add_argument("--Lt", type=int, help="Time extent of ensemble", required=True)
         parser.add_argument("--Ls", type=int, help="Spatial extent of ensemble", required=True)
         parser.add_argument("--Nev", type=int, help="Number of LapH eigenvectors per time slice", required=True)


### PR DESCRIPTION
This adds `on the fly` functionality to `archive_eigsys.py`. Unlike `archive_perams.py`, no temporary files are used at all. This requires more care on the side of the user (as any number of things may go wrong), but given the size of the eigensystems on large lattices, it is a reasonable compromise, I would say.

The original way of creating a transfer list should still work as before (i.e., when `--otf` is not specified).